### PR TITLE
Add ROGUEOPTS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ if (EXISTS ${picoVscode})
     include(${picoVscode})
 endif()
 # ====================================================================================
-set(PICO_BOARD pimoroni_pico_plus2_w_rp2350 CACHE STRING "Board type")
-set(PICOCALC_ROGUE_VERSION "0.2" CACHE STRING "PicoCalc Rogue version")
+set(PICO_BOARD pico2_w CACHE STRING "Board type")
+set(PICOCALC_ROGUE_VERSION "0.3" CACHE STRING "PicoCalc Rogue version")
 
 # Pull in Raspberry Pi Pico SDK (must be before project)
 include(pico_sdk_import.cmake)

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -357,7 +357,13 @@ conceptions of the way rogue should do things, there are a
 set of options you can set that cause rogue to behave in
 various different ways.
 
-## 8.1 Setting the options
+### 8.1.  Setting the options
+
+There  are  two  ways to set the options.  The first is
+with the "o" command  of  rogue;  the  second  is  with  the
+"ROGUEOPTS" environment variable.
+
+#### 8.1.1.  Using the `o' command
 
 When you type `o` in rogue, it
 clears the screen and displays the current settings for all
@@ -371,6 +377,19 @@ value. For boolean options this merely involves typing
 `t` for true or `f` for false. For
 string options, type the new value followed by a
 `Enter`.
+
+### 8.1.2.  Using the ROGUEOPTS variable
+
+The ROGUEOPTS variable is a string containing  a  comma
+separated  list  of  initial values for the various options.
+Boolean variables can be turned on by listing their name  or
+turned  off by putting a "no" in front of the name.  Thus to
+set up an environment variable so that jump is on, terse  is
+off, and the name is set to "Blue Meanie", use the text
+
+    ROGUEOPTS=jump,noterse,name=Blue Meanie
+
+Place this text in the `/Rogue/rogue.env` file.
 
 ## 8.2. Option list
 

--- a/patches/rogue.patch
+++ b/patches/rogue.patch
@@ -130,7 +130,7 @@
  }
  
 --- a/rogue/rip.c	2025-08-16 17:49:39
-+++ b/rogue/rip.c	2025-08-25 20:19:19
++++ b/rogue/rip.c	2025-08-26 21:44:16
 @@ -21,6 +21,9 @@
  #include <curses.h>
  #include "rogue.h"
@@ -141,15 +141,14 @@
  
  static char *rip[] = {
  "                       __________\n",
-@@ -270,8 +273,10 @@
+@@ -268,10 +271,7 @@
+     move(LINES - 1, 0);
+     refresh();
      score(purse, amulet ? 3 : 0, monst);
-     printf("[Press return to continue]");
-     fflush(stdout);
+-    printf("[Press return to continue]");
+-    fflush(stdout);
 -    (void) fgets(prbuf,10,stdin);
 -    my_exit(0);
-+	PDC_flushinp();
-+    while (getch() != '\n')
-+	;
 +    rogue_exit(0);
  }
  


### PR DESCRIPTION
This pull request introduces several improvements and features to environment variable handling for the Rogue project, updates documentation to clarify option configuration, and makes minor versioning and board selection adjustments. The most notable change is the addition of support for loading environment variables from a configuration file, enabling more flexible user customization.

**Environment variable handling:**

* Added logic in `main.c` to read environment variables from `/Rogue/rogue.env` at startup, parse up to 16 variables, and set them in a custom `environment` array, which is then assigned to `environ`. This allows users to configure game options via a file. [[1]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecR26-R34) [[2]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecR188-R222)
* Included `<ctype.h>` to support whitespace trimming when parsing environment variable lines.

**Documentation improvements:**

* Expanded the "Setting the options" section in `GUIDE.md` to explain both the in-game `o` command and the new `ROGUEOPTS` environment variable, including usage examples and file location. [[1]](diffhunk://#diff-f0d91300831f8bc350b2883e8adf82bdbcb79f482585168420831991e320ade7L360-R366) [[2]](diffhunk://#diff-f0d91300831f8bc350b2883e8adf82bdbcb79f482585168420831991e320ade7R381-R393)

**Build and configuration updates:**

* Changed default `PICO_BOARD` to `pico2_w` and incremented `PICOCALC_ROGUE_VERSION` to "0.3" in `CMakeLists.txt`.

**Patch maintenance:**

* Updated `patches/rogue.patch` to change the way the game exits after displaying the RIP (rest in peace) screen, now calling `rogue_exit(0)` directly instead of waiting for user input. [[1]](diffhunk://#diff-09c8668bd27af01138306a01dd4ec022b5d9cc54f1a64bf7b7d90616b94da5a8L133-R133) [[2]](diffhunk://#diff-09c8668bd27af01138306a01dd4ec022b5d9cc54f1a64bf7b7d90616b94da5a8L144-L152)