### PR TITLE
Fix score memory initialisation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 working
 rogue
 pdcurses
+.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ if (EXISTS ${picoVscode})
     include(${picoVscode})
 endif()
 # ====================================================================================
-set(PICO_BOARD pico2_w CACHE STRING "Board type")
-set(PICOCALC_ROGUE_VERSION "0.3" CACHE STRING "PicoCalc Rogue version")
+set(PICO_BOARD pico2 CACHE STRING "Board type")
+set(PICOCALC_ROGUE_VERSION "0.4" CACHE STRING "PicoCalc Rogue version")
 
 # Pull in Raspberry Pi Pico SDK (must be before project)
 include(pico_sdk_import.cmake)

--- a/main.c
+++ b/main.c
@@ -116,6 +116,10 @@ int main(int argc, char **argv, char **envp)
         }
         free(top_ten);
     }
+    else
+    {
+        lcd_putstr(14, 8, "Error allocating memory for scores.");
+    }
 
     // Show battery status, bottom corner
     int raw_level = sb_read_battery();

--- a/main.c
+++ b/main.c
@@ -77,39 +77,44 @@ int main(int argc, char **argv, char **envp)
     snprintf(buffer, sizeof(buffer), "Version %s. Port to PicoCalc v%s.", release, PICOCALC_ROGUE_VERSION);
     lcd_putstr((64 - strlen(buffer)) >> 1, 4, buffer);
 
-    // Display top ten scores
-    lcd_putstr(24, 8, "Top Ten Scores");
-    lcd_putstr(4, 10, "Score");
-    lcd_putstr(11, 10, "Name                                                ");
-
-    SCORE *top_ten = (SCORE *) malloc(numscores * sizeof (SCORE));
-    SCORE *endp = &top_ten[numscores];
-    open_score();
-    rd_score(top_ten);
-
-    int y = 11;
-    for (SCORE *scp = top_ten; scp < endp; scp++)
+    SCORE *top_ten = (SCORE *)calloc(numscores, sizeof(SCORE));
+    if (top_ten)
     {
-        if (scp->sc_score == 0)
-            break;
+        // Display top ten scores
+        lcd_putstr(24, 8, "Top Ten Scores");
+        lcd_putstr(4, 10, "Score");
+        lcd_putstr(11, 10, "Name                                                ");
 
-        if (scp->sc_flags == 0 || scp->sc_flags == 3)
+
+        SCORE *endp = &top_ten[numscores];
+        open_score();
+        rd_score(top_ten);
+
+        int y = 11;
+        for (SCORE *scp = top_ten; scp < endp; scp++)
         {
-            snprintf(buffer, sizeof(buffer),
-                "%2d  %5d  %s: %s on level %d by %s.",
-                (int) (scp - top_ten + 1), scp->sc_score,
-                scp->sc_name, reason[scp->sc_flags],
-                scp->sc_level, killname((char) scp->sc_monster, TRUE));
+            if (scp->sc_score == 0)
+                break;
+
+            if (scp->sc_flags == 0 || scp->sc_flags == 3)
+            {
+                snprintf(buffer, sizeof(buffer),
+                    "%2d  %5d  %s: %s on level %d by %s.",
+                    (int) (scp - top_ten + 1), scp->sc_score,
+                    scp->sc_name, reason[scp->sc_flags],
+                    scp->sc_level, killname((char) scp->sc_monster, TRUE));
+            }
+            else
+            {
+                snprintf(buffer, sizeof(buffer),
+                    "%2d  %5d  %s: %s on level %d.",
+                    (int) (scp - top_ten + 1), scp->sc_score,
+                    scp->sc_name, reason[scp->sc_flags],
+                    scp->sc_level);
+            }
+            lcd_putstr(0, y++, buffer);
         }
-        else
-        {
-            snprintf(buffer, sizeof(buffer),
-                "%2d  %5d  %s: %s on level %d.",
-                (int) (scp - top_ten + 1), scp->sc_score,
-                scp->sc_name, reason[scp->sc_flags],
-                scp->sc_level);
-        }
-        lcd_putstr(0, y++, buffer);
+        free(top_ten);
     }
 
     // Show battery status, bottom corner


### PR DESCRIPTION
This pull request includes several improvements and updates across the project, focusing on updating versioning, improving memory management, and updating a submodule.

**Version and Board Updates:**

* Updated the `PICOCALC_ROGUE_VERSION` from `0.3` to `0.4`.

**Memory Management Improvements:**

* Replaced the use of `malloc` with `calloc` for allocating the `top_ten` scores array in `main.c`, ensuring the memory is zero-initialized.
* Added a check for successful allocation of `top_ten` and ensured the allocated memory is freed after use to prevent memory leaks. [[1]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecR80-R88) [[2]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecR117-R118)

**Submodule Update:**

* Updated the `modules/PDCurses` submodule to a newer commit, pulling in the latest changes from the dependency.