### PR TITLE
Add power off after save and quit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if (EXISTS ${picoVscode})
 endif()
 # ====================================================================================
 set(PICO_BOARD pico2 CACHE STRING "Board type")
-set(PICOCALC_ROGUE_VERSION "0.4" CACHE STRING "PicoCalc Rogue version")
+set(PICOCALC_ROGUE_VERSION "1.0" CACHE STRING "PicoCalc Rogue version")
 
 # Pull in Raspberry Pi Pico SDK (must be before project)
 include(pico_sdk_import.cmake)

--- a/main.c
+++ b/main.c
@@ -60,13 +60,10 @@ void rogue_exit(int status)
         char *msg = power_off_msgs[get_rand_32() % (sizeof(power_off_msgs) / sizeof(char *))];
         lcd_putstr((64 - strlen(msg)) >> 1, 16, msg);
 
-        if (sb_is_power_off_supported())
+        sb_write_power_off_delay(6);
+        while (1)
         {
-            sb_write_power_off_delay(6);
-            while (1)
-            {
-                tight_loop_contents();
-            }
+            tight_loop_contents();
         }
     }
 

--- a/patches/rogue.patch
+++ b/patches/rogue.patch
@@ -13,12 +13,12 @@
  		when 'v':
  		    after = FALSE;
 -		    msg("version %s. (mctesq was here)", release);
-+		    msg("version %s. (mctesq was here) PicoCalc v%s.", release, PICOCALC_ROGUE_VERSION);
++		    msg("version %s. (mctesq was here) Port to PicoCalc v%s.", release, PICOCALC_ROGUE_VERSION);
  		when 'S': 
  		    after = FALSE;
  		    save_game();
 --- a/rogue/extern.c	2025-08-18 21:28:34
-+++ b/rogue/extern.c	2025-08-18 21:22:05
++++ b/rogue/extern.c	2025-08-29 17:18:18
 @@ -348,14 +348,14 @@
      {CTRL('U'),	"	run up & right until adjacent",		FALSE},
      {CTRL('B'),	"	run down & left until adjacent",	FALSE},
@@ -40,7 +40,7 @@
      {'>',	"	go down a staircase",			TRUE},
      {'<',	"	go up a staircase",			TRUE},
      {'.',	"	rest for a turn",			TRUE},
-@@ -377,7 +377,7 @@
+@@ -377,15 +377,14 @@
      {']',	"	print current armor",			TRUE},
      {'=',	"	print current rings",			TRUE},
      {'@',	"	print current stats",			TRUE},
@@ -49,17 +49,17 @@
      {'o',	"	examine/set options",			TRUE},
      {CTRL('R'),	"	redraw screen",				TRUE},
      {CTRL('P'),	"	repeat last message",			TRUE},
-@@ -385,7 +385,7 @@
+     {ESCAPE,	"	cancel command",			TRUE},
      {'S',	"	save game",				TRUE},
      {'Q',	"	quit",					TRUE},
-     {'!',	"	shell escape",				TRUE},
+-    {'!',	"	shell escape",				TRUE},
 -    {'F',	"<dir>	fight till either of you dies",		TRUE},
 +    {'F',	"<dir>	fight till one dies",		TRUE},
      {'v',	"	print version number",			TRUE},
      {0,		NULL }
  };
 --- a/rogue/io.c	2025-08-18 21:28:38
-+++ b/rogue/io.c	2025-08-24 22:44:45
++++ b/rogue/io.c	2025-08-29 17:15:06
 @@ -220,7 +220,7 @@
      if (stat_msg)
      {
@@ -79,7 +79,7 @@
  	    max_stats.s_str, 10 - s_arm, pstats.s_lvl, pstats.s_exp,
  	    state_name[hungry_state]);
 --- a/rogue/main.c	2025-08-23 15:54:36
-+++ b/rogue/main.c	2025-08-25 19:33:19
++++ b/rogue/main.c	2025-08-29 21:17:44
 @@ -13,14 +13,17 @@
  #include <signal.h>
  #include <time.h>
@@ -99,20 +99,7 @@
  {
      char *env;
      int lowtime;
-@@ -45,11 +48,8 @@
-     /*
-      * get home and options from environment
-      */
--
--    strncpy(home, md_gethomedir(), MAXSTR);
- 
--    strcpy(file_name, home);
--    strcat(file_name, "rogue.save");
-+    strcpy(file_name, "/Rogue/rogue.save");
- 
-     if ((env = getenv("ROGUEOPTS")) != NULL)
- 	parse_opts(env);
-@@ -185,7 +185,7 @@
+@@ -185,7 +188,7 @@
  int
  rnd(int range)
  {
@@ -121,7 +108,16 @@
  }
  
  /*
-@@ -391,6 +391,6 @@
+@@ -308,7 +311,7 @@
+ 	move(LINES - 1, 0);
+ 	refresh();
+ 	score(purse, 1, 0);
+-	my_exit(0);
++	my_exit(1);
+     }
+     else
+     {
+@@ -391,6 +394,6 @@
  my_exit(int st)
  {
      resetltchars();
@@ -130,29 +126,17 @@
  }
  
 --- a/rogue/rip.c	2025-08-16 17:49:39
-+++ b/rogue/rip.c	2025-08-26 21:44:16
-@@ -21,6 +21,9 @@
- #include <curses.h>
- #include "rogue.h"
- #include "score.h"
-+
-+extern void rogue_exit(int status);
-+extern void PDC_flushinp(void);
- 
- static char *rip[] = {
- "                       __________\n",
-@@ -268,10 +271,7 @@
++++ b/rogue/rip.c	2025-08-29 21:54:41
+@@ -268,9 +268,6 @@
      move(LINES - 1, 0);
      refresh();
      score(purse, amulet ? 3 : 0, monst);
 -    printf("[Press return to continue]");
 -    fflush(stdout);
 -    (void) fgets(prbuf,10,stdin);
--    my_exit(0);
-+    rogue_exit(0);
+     my_exit(0);
  }
  
- /*
 --- a/rogue/rogue.h	2025-08-18 21:28:51
 +++ b/rogue/rogue.h	2025-08-23 15:39:37
 @@ -11,6 +11,7 @@
@@ -175,31 +159,22 @@
  #define BORE_LEVEL	50
  
 --- a/rogue/save.c	2025-08-16 17:49:39
-+++ b/rogue/save.c	2025-08-25 19:25:02
-@@ -20,6 +20,8 @@
- #include "rogue.h"
- #include "score.h"
- 
-+extern void rogue_exit(int status);
-+
- typedef struct stat STAT;
- 
- extern char version[], encstr[];
-@@ -128,7 +130,7 @@
++++ b/rogue/save.c	2025-08-29 21:57:03
+@@ -128,7 +128,7 @@
      if (file_name[0] != '\0' && ((savef = fopen(file_name, "w")) != NULL ||
  	(md_unlink_open_file(file_name, savef) >= 0 && (savef = fopen(file_name, "w")) != NULL)))
  	    save_file(savef);
 -    exit(0);
-+    rogue_exit(0);
++    my_exit(1);
  }
  
  /*
-@@ -151,7 +153,7 @@
+@@ -151,7 +151,7 @@
      rs_save_file(savef);
      fflush(savef);
      fclose(savef);
 -    exit(0);
-+    rogue_exit(0);
++    my_exit(1);
  }
  
  /*


### PR DESCRIPTION
This pull request introduces several improvements and changes to the PicoCalc Rogue project, focusing on user experience enhancements, save file handling, and codebase updates for better integration and maintainability. The most significant updates include displaying randomized power-off messages, saving game files to the user's home directory, and updating versioning and submodules.

**User Experience Enhancements:**

* Added randomized, friendly power-off messages displayed when the device is powered off after exiting the game, improving user interaction. (`main.c`, `power_off_msgs`, `rogue_exit`) [[1]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecL30-R43) [[2]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecR55-R72)

**Save File Handling:**

* Changed save file logic to store and load `rogue.save` from the user's home directory instead of a fixed path, increasing portability and user-friendliness. (`main.c`, `file_name` construction and usage)
* Updated related patch logic to use the new save file location and ensure consistent exit handling after saving. (`patches/rogue.patch`) [[1]](diffhunk://#diff-09c8668bd27af01138306a01dd4ec022b5d9cc54f1a64bf7b7d90616b94da5a8L102-R102) [[2]](diffhunk://#diff-09c8668bd27af01138306a01dd4ec022b5d9cc54f1a64bf7b7d90616b94da5a8L178-R177)

**Versioning and Submodules:**

* Updated the `PICOCALC_ROGUE_VERSION` from "0.4" to "1.0" to reflect the new release. (`CMakeLists.txt`)
* Bumped the `picocalc-text-starter` submodule to the latest commit. (`modules/picocalc-text-starter`)

**Miscellaneous Improvements:**

* Improved version message formatting and clarified help text in the patched Rogue code. (`patches/rogue.patch`) [[1]](diffhunk://#diff-09c8668bd27af01138306a01dd4ec022b5d9cc54f1a64bf7b7d90616b94da5a8L16-R21) [[2]](diffhunk://#diff-09c8668bd27af01138306a01dd4ec022b5d9cc54f1a64bf7b7d90616b94da5a8L52-R62)
* Minor code cleanups and formatting adjustments for better readability. (`main.c`) [[1]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecL19) [[2]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecL54-R83) [[3]](diffhunk://#diff-a0cb465674c1b01a07d361f25a0ef2b0214b7dfe9412b7777f89add956da10ecL88)